### PR TITLE
Fix for issue #34 : java.time.YearMonth getDateValue detected as protobuf

### DIFF
--- a/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProtobufAccessorNamingStrategy.java
+++ b/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProtobufAccessorNamingStrategy.java
@@ -196,7 +196,7 @@ public class ProtobufAccessorNamingStrategy extends DefaultAccessorNamingStrateg
 	public String getElementName(ExecutableElement adderMethod) {
 
 		String methodName = super.getElementName(adderMethod);
-		if (protobufMesageOrBuilderType != null && isMethodFromProtobufGeneratedClass(adderMethod)) {
+		if (isMethodFromProtobufGeneratedClass(adderMethod)) {
 			String singularizedMethodName = Nouns.singularize(methodName);
 			methodName = singularizedMethodName;
 		}
@@ -265,6 +265,6 @@ public class ProtobufAccessorNamingStrategy extends DefaultAccessorNamingStrateg
 
 	private boolean isMethodFromProtobufGeneratedClass(ExecutableElement method) {
 		Element receiver = method.getEnclosingElement();
-		return receiver != null && typeUtils.isAssignable(receiver.asType(), protobufMesageOrBuilderType);
+		return protobufMesageOrBuilderType != null && receiver != null && typeUtils.isAssignable(receiver.asType(), protobufMesageOrBuilderType);
 	}
 }

--- a/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProtobufAccessorNamingStrategy.java
+++ b/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProtobufAccessorNamingStrategy.java
@@ -73,6 +73,9 @@ public class ProtobufAccessorNamingStrategy extends DefaultAccessorNamingStrateg
 	}
 
 	private boolean isSpecialMethod(ExecutableElement method) {
+		if (!isMethodFromProtobufGeneratedClass(method)) {
+			return false;
+		}
 		String methodName = method.getSimpleName().toString();
 
 		for (String checkMethod : INTERNAL_SPECIAL_METHOD_ENDINGS) {
@@ -193,8 +196,7 @@ public class ProtobufAccessorNamingStrategy extends DefaultAccessorNamingStrateg
 	public String getElementName(ExecutableElement adderMethod) {
 
 		String methodName = super.getElementName(adderMethod);
-		Element receiver = adderMethod.getEnclosingElement();
-		if (receiver != null && protobufMesageOrBuilderType != null && typeUtils.isAssignable(receiver.asType(), protobufMesageOrBuilderType)) {
+		if (protobufMesageOrBuilderType != null && isMethodFromProtobufGeneratedClass(adderMethod)) {
 			String singularizedMethodName = Nouns.singularize(methodName);
 			methodName = singularizedMethodName;
 		}
@@ -261,4 +263,8 @@ public class ProtobufAccessorNamingStrategy extends DefaultAccessorNamingStrateg
 		return false;
 	}
 
+	private boolean isMethodFromProtobufGeneratedClass(ExecutableElement method) {
+		Element receiver = method.getEnclosingElement();
+		return receiver != null && typeUtils.isAssignable(receiver.asType(), protobufMesageOrBuilderType);
+	}
 }


### PR DESCRIPTION
Special protobuf methods prefixes/suffixes will no longer be tested if the element parsed is not from a subclass of com.google.protobuf.MessageLiteOrBuilder