### PR TITLE
Pass mapstructSpi.enumPostfix as compilerArg

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ which require manual mapping.
 Implements ```EnumMappingStrategy``` and provides complete enum constant mappings if you follow Googles style guide for
 enums https://developers.google.com/protocol-buffers/docs/style#enums
 
+If needed you can specify a different postfix for the 0 value enum by passing in `mapstructSpi.enumPostfix` as a compilerArg.
+Otherwise, this will default to `UNSPECIFIED` as per the Google style guide.
+
+```xml
+
+<plugin>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <configuration>
+        <annotationProcessorPaths>
+            <path>
+                <groupId>no.entur.mapstruct.spi</groupId>
+                <artifactId>protobuf-spi-impl</artifactId>
+                <version>LATEST.VERSION</version>
+            </path>
+        </annotationProcessorPaths>
+        <compilerArgs>
+            <arg>-AmapstructSpi.enumPostfix=UNSPECIFIED</arg>
+        </compilerArgs>
+    </configuration>
+</plugin>
+
+```
+
+
 ## Support - Mapping funcions:
 
 Standard mapping functions between often used proto types and java types:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ which require manual mapping.
 Implements ```EnumMappingStrategy``` and provides complete enum constant mappings if you follow Googles style guide for
 enums https://developers.google.com/protocol-buffers/docs/style#enums
 
-If needed you can specify a different postfix for the 0 value enum by passing in `mapstructSpi.enumPostfix` as a compilerArg.
+If needed you can specify a different postfix for the 0 value enum by passing in `mapstructSpi.enumPostfixOverrides` as 
+a compilerArg in the format of:
+
+`-AmapstructSpi.enumPostfixOverrides=com.package.root.a=POSTFIX_1,com.package.root.b=POSTFIX_2,`
+
 Otherwise, this will default to `UNSPECIFIED` as per the Google style guide.
 
 ```xml
@@ -37,7 +41,7 @@ Otherwise, this will default to `UNSPECIFIED` as per the Google style guide.
             </path>
         </annotationProcessorPaths>
         <compilerArgs>
-            <arg>-AmapstructSpi.enumPostfix=UNSPECIFIED</arg>
+            <arg>-AmapstructSpi.enumPostfixOverrides=com.company.name=INVALID</arg>
         </compilerArgs>
     </configuration>
 </plugin>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ enums https://developers.google.com/protocol-buffers/docs/style#enums
 If needed you can specify a different postfix for the 0 value enum by passing in `mapstructSpi.enumPostfixOverrides` as 
 a compilerArg in the format of:
 
-`-AmapstructSpi.enumPostfixOverrides=com.package.root.a=POSTFIX_1,com.package.root.b=POSTFIX_2,`
+`-AmapstructSpi.enumPostfixOverrides=com.package.root.a=POSTFIX_1,com.package.root.b=POSTFIX_2`
 
 Otherwise, this will default to `UNSPECIFIED` as per the Google style guide.
 

--- a/spi-impl/pom.xml
+++ b/spi-impl/pom.xml
@@ -52,6 +52,28 @@
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgument>-proc:none</compilerArgument>
+                            <includes>
+                                <include>no/entur/mapstruct/spi/protobuf/ProcessingEnvOptionsHolder.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-project</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProcessingEnvOptionsHolder.java
+++ b/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProcessingEnvOptionsHolder.java
@@ -40,10 +40,10 @@ import java.util.Set;
  * that is accessible by the MapStruct classes which would otherwise not have visibility to these.
  */
 @SupportedAnnotationTypes({})
-@SupportedOptions({ProcessingEnvOptionsHolder.ENUM_POSTFIX_OVERRIDE})
+@SupportedOptions({ProcessingEnvOptionsHolder.ENUM_POSTFIX_OVERRIDES})
 public class ProcessingEnvOptionsHolder extends AbstractProcessor {
 
-    static final String ENUM_POSTFIX_OVERRIDE = "mapstructSpi.enumPostfixOverrides";
+    static final String ENUM_POSTFIX_OVERRIDES = "mapstructSpi.enumPostfixOverrides";
 
     private static Map<String, String> OPTIONS;
 

--- a/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProcessingEnvOptionsHolder.java
+++ b/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProcessingEnvOptionsHolder.java
@@ -40,10 +40,10 @@ import java.util.Set;
  * that is accessible by the MapStruct classes which would otherwise not have visibility to these.
  */
 @SupportedAnnotationTypes({})
-@SupportedOptions({ProcessingEnvOptionsHolder.ENUM_POSTFIX})
+@SupportedOptions({ProcessingEnvOptionsHolder.ENUM_POSTFIX_OVERRIDE})
 public class ProcessingEnvOptionsHolder extends AbstractProcessor {
 
-    static final String ENUM_POSTFIX = "mapstructSpi.enumPostfix";
+    static final String ENUM_POSTFIX_OVERRIDE = "mapstructSpi.enumPostfixOverrides";
 
     private static Map<String, String> OPTIONS;
 
@@ -63,10 +63,17 @@ public class ProcessingEnvOptionsHolder extends AbstractProcessor {
         return SourceVersion.latestSupported();
     }
 
-    static String getOption(String key, String defaultValue) {
+    static boolean containsKey(String key) {
         if (OPTIONS == null) {
             throw new IllegalStateException("ProcessingEnvOptionsHolder not initialized yet.");
         }
-        return OPTIONS.getOrDefault(key, defaultValue);
+        return OPTIONS.containsKey(key);
+    }
+
+    static String getOption(String key) {
+        if (OPTIONS == null) {
+            throw new IllegalStateException("ProcessingEnvOptionsHolder not initialized yet.");
+        }
+        return OPTIONS.get(key);
     }
 }

--- a/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProcessingEnvOptionsHolder.java
+++ b/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProcessingEnvOptionsHolder.java
@@ -1,0 +1,72 @@
+package no.entur.mapstruct.spi.protobuf;
+
+/*-
+ * #%L
+ * protobuf-spi-impl
+ * %%
+ * Copyright (C) 2019 - 2021 Entur
+ * %%
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ * 
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * 
+ * http://ec.europa.eu/idabc/eupl5
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This is not a true processor. It merely exists to pass the defined supported options to a global context
+ * that is accessible by the MapStruct classes which would otherwise not have visibility to these.
+ */
+@SupportedAnnotationTypes({})
+@SupportedOptions({ProcessingEnvOptionsHolder.ENUM_POSTFIX})
+public class ProcessingEnvOptionsHolder extends AbstractProcessor {
+
+    static final String ENUM_POSTFIX = "mapstructSpi.enumPostfix";
+
+    private static Map<String, String> OPTIONS;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        OPTIONS = ImmutableMap.copyOf(processingEnv.getOptions());
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    static String getOption(String key, String defaultValue) {
+        if (OPTIONS == null) {
+            throw new IllegalStateException("ProcessingEnvOptionsHolder not initialized yet.");
+        }
+        return OPTIONS.getOrDefault(key, defaultValue);
+    }
+}

--- a/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProtobufEnumMappingStrategy.java
+++ b/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProtobufEnumMappingStrategy.java
@@ -38,7 +38,6 @@ import org.mapstruct.MappingConstants;
 import org.mapstruct.ap.spi.DefaultEnumMappingStrategy;
 
 import com.google.common.base.CaseFormat;
-import org.mapstruct.ap.spi.MapStructProcessingEnvironment;
 
 public class ProtobufEnumMappingStrategy extends DefaultEnumMappingStrategy {
 
@@ -69,9 +68,9 @@ public class ProtobufEnumMappingStrategy extends DefaultEnumMappingStrategy {
 	}
 
 	private void initEnumPostfixOverrides() {
-		if (ProcessingEnvOptionsHolder.containsKey(ProcessingEnvOptionsHolder.ENUM_POSTFIX_OVERRIDE)) {
+		if (ProcessingEnvOptionsHolder.containsKey(ProcessingEnvOptionsHolder.ENUM_POSTFIX_OVERRIDES)) {
 			String[] postfixOverrides = ProcessingEnvOptionsHolder
-					.getOption(ProcessingEnvOptionsHolder.ENUM_POSTFIX_OVERRIDE)
+					.getOption(ProcessingEnvOptionsHolder.ENUM_POSTFIX_OVERRIDES)
 					.split(",");
 
 			enumPostfixOverrides = Arrays.stream(postfixOverrides)

--- a/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProtobufEnumMappingStrategy.java
+++ b/spi-impl/src/main/java/no/entur/mapstruct/spi/protobuf/ProtobufEnumMappingStrategy.java
@@ -45,10 +45,11 @@ public class ProtobufEnumMappingStrategy extends DefaultEnumMappingStrategy {
 	/**
 	 * The enum constant postfix used as default value in protobuf, ie for enum "Cake" the default constant should be CAKE_UNSPECIFIED = 0; This is the
 	 * recommended style according to Googles style guide https://developers.google.com/protocol-buffers/docs/style#enums . If you use some other pattern in
-	 * your protobuf files you can simply subclass this class and override this method.
+	 * your protobuf files you can pass in "mapstructSpi.enumPostfix" as a compilerArg.
 	 */
 	protected String getDefaultEnumConstant() {
-		return DEFAULT_ENUM_POSTFIX;
+		return ProcessingEnvOptionsHolder
+				.getOption(ProcessingEnvOptionsHolder.ENUM_POSTFIX, DEFAULT_ENUM_POSTFIX);
 	}
 
 	// @Override

--- a/spi-impl/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/spi-impl/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+no.entur.mapstruct.spi.protobuf.ProcessingEnvOptionsHolder

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -73,7 +73,7 @@
                         </path>
                     </annotationProcessorPaths>
                     <compilerArgs>
-                        <arg>-AmapstructSpi.enumPostfix=UNSPECIFIED</arg>
+                        <arg>-AmapstructSpi.enumPostfixOverrides=no.entur.mapstruct.example.EnumPostfixOverrideProtos=INVALID</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -72,6 +72,9 @@
                   (in this case from the local M2-repo cache). -->
                         </path>
                     </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-AmapstructSpi.enumPostfix=UNSPECIFIED</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/usage/src/main/java/no/entur/mapstruct/example/EnumPostfixOverrideMapper.java
+++ b/usage/src/main/java/no/entur/mapstruct/example/EnumPostfixOverrideMapper.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ * and/or other contributors as indicated by the @authors tag. See the
+ * copyright.txt file in the distribution for a full listing of all
+ * contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.entur.mapstruct.example;
+
+/*-
+ * #%L
+ * protobuf-usage
+ * %%
+ * Copyright (C) 2019 - 2020 Entur
+ * %%
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ * 
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * 
+ * http://ec.europa.eu/idabc/eupl5
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ * #L%
+ */
+
+import no.entur.mapstruct.example.EnumPostfixOverrideProtos.EnumPostfixOverrideValuesDTO;
+import no.entur.mapstruct.spi.protobuf.EnumPostfixOverrideValues;
+import no.entur.mapstruct.spi.protobuf.User;
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValueCheckStrategy;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED, nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS, unmappedSourcePolicy = ReportingPolicy.ERROR, unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface EnumPostfixOverrideMapper {
+
+	EnumPostfixOverrideMapper INSTANCE = Mappers.getMapper(EnumPostfixOverrideMapper.class);
+
+	EnumPostfixOverrideValuesDTO map(EnumPostfixOverrideValues user);
+
+	EnumPostfixOverrideValues map(EnumPostfixOverrideValuesDTO userDTO);
+
+}

--- a/usage/src/main/java/no/entur/mapstruct/example/EnumPostfixOverrideMapper.java
+++ b/usage/src/main/java/no/entur/mapstruct/example/EnumPostfixOverrideMapper.java
@@ -55,8 +55,8 @@ public interface EnumPostfixOverrideMapper {
 
 	EnumPostfixOverrideMapper INSTANCE = Mappers.getMapper(EnumPostfixOverrideMapper.class);
 
-	EnumPostfixOverrideValuesDTO map(EnumPostfixOverrideValues user);
+	EnumPostfixOverrideValuesDTO map(EnumPostfixOverrideValues value);
 
-	EnumPostfixOverrideValues map(EnumPostfixOverrideValuesDTO userDTO);
+	EnumPostfixOverrideValues map(EnumPostfixOverrideValuesDTO dto);
 
 }

--- a/usage/src/main/java/no/entur/mapstruct/spi/protobuf/EnumPostfixOverrideValues.java
+++ b/usage/src/main/java/no/entur/mapstruct/spi/protobuf/EnumPostfixOverrideValues.java
@@ -1,0 +1,28 @@
+package no.entur.mapstruct.spi.protobuf;
+
+/*-
+ * #%L
+ * protobuf-usage
+ * %%
+ * Copyright (C) 2019 - 2021 Entur
+ * %%
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ * 
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * 
+ * http://ec.europa.eu/idabc/eupl5
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ * #L%
+ */
+
+public enum EnumPostfixOverrideValues {
+    ONE, TWO
+}

--- a/usage/src/main/proto/EnumPostfixOverride.proto
+++ b/usage/src/main/proto/EnumPostfixOverride.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "no.entur.mapstruct.example";
+option java_outer_classname = "EnumPostfixOverrideProtos";
+
+enum EnumPostfixOverrideValuesDTO {
+  ENUM_POSTFIX_OVERRIDE_VALUES_D_T_O_INVALID = 0;
+  ENUM_POSTFIX_OVERRIDE_VALUES_D_T_O_ONE = 1;
+  ENUM_POSTFIX_OVERRIDE_VALUES_D_T_O_TWO = 2;
+}

--- a/usage/src/test/java/no/entur/mapstruct/example/MappingTest.java
+++ b/usage/src/test/java/no/entur/mapstruct/example/MappingTest.java
@@ -47,11 +47,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.Arrays;
 import java.util.Map;
 
+import no.entur.mapstruct.spi.protobuf.EnumPostfixOverrideValues;
 import org.junit.jupiter.api.Test;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import no.entur.mapstruct.example.EnumPostfixOverrideProtos.EnumPostfixOverrideValuesDTO;
 import no.entur.mapstruct.example.UserProtos.UserDTO;
 import no.entur.mapstruct.spi.protobuf.Department;
 import no.entur.mapstruct.spi.protobuf.MultiNumber;
@@ -236,5 +238,14 @@ public class MappingTest {
 
 		assertEquals(null, back.getId());
 		assertEquals("test", back.getEmail());
+	}
+
+	@Test
+	public void testEnumPostfixOverride() {
+		EnumPostfixOverrideValues enumValue = EnumPostfixOverrideValues.TWO;
+		EnumPostfixOverrideValuesDTO dto = EnumPostfixOverrideMapper.INSTANCE.map(enumValue);
+		EnumPostfixOverrideValues back = EnumPostfixOverrideMapper.INSTANCE.map(dto);
+
+		assertEquals(enumValue, back);
 	}
 }


### PR DESCRIPTION
Allow configuration of enumPostfix by means of a compilerArg.

e.g.
```
<compilerArgs>
    <arg>-AmapstructSpi.enumPostfixOverrides=com.package.root.a=POSTFIX_1,com.package.root.b=POSTFIX_2</arg>
</compilerArgs>
```

Unfortunately I was unable to find a "clean" way to pass the `ProcessingEnvironment` options from MapStruct's `MappingProcessor` so I had to create my own to pass the options to a static variable (terrible, I know). Please let me know if you have any better suggestions.

This _should_ be safe because the processors are all initialized together first, before calling `process` thus the `OPTIONS` static field should be initialized by the time it is called on by `ProtobufEnumMappingStrategy`.