### PR TITLE
176 mappers should never return null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hs_err_pid*
 
 .README.md.html
 
+target/

--- a/support-core/src/main/java/no/entur/abt/mapstruct/common/ProtobufStandardMappings.java
+++ b/support-core/src/main/java/no/entur/abt/mapstruct/common/ProtobufStandardMappings.java
@@ -9,12 +9,12 @@ package no.entur.abt.mapstruct.common;
  * Licensed under the EUPL, Version 1.1 or – as soon they will be
  * approved by the European Commission - subsequent versions of the
  * EUPL (the "Licence");
- * 
+ *
  * You may not use this work except in compliance with the Licence.
  * You may obtain a copy of the Licence at:
- * 
+ *
  * http://ec.europa.eu/idabc/eupl5
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the Licence is distributed on an "AS IS" basis,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,44 +50,44 @@ public interface ProtobufStandardMappings {
 	}
 
 	default byte[] mapByteString(ByteString in) {
-		if (in != null && !in.isEmpty()) {
-			return in.toByteArray();
-		}
-
-		return null;
+		return in != null ? in.toByteArray() : new byte[0];
 	}
 
 	default ByteString mapByteStringToString(String string) {
-		return ByteString.copyFromUtf8(string);
+		return ByteString.copyFromUtf8(string != null ? string : "");
 	}
 
 	default String mapStringToByteString(ByteString in) {
-		if (in != null && !in.isEmpty()) {
-			return in.toStringUtf8();
-		}
-
-		return null;
+		return in != null ? in.toStringUtf8() : "";
 	}
 
 	default com.google.type.Date mapLocalDate(LocalDate t) {
-		return com.google.type.Date.newBuilder().setYear(t.getYear()).setMonth(t.getMonthValue()).setDay(t.getDayOfMonth()).build();
+		return t != null
+				? com.google.type.Date.newBuilder().setYear(t.getYear()).setMonth(t.getMonthValue()).setDay(t.getDayOfMonth()).build()
+				: com.google.type.Date.getDefaultInstance();
 	}
 
 	default LocalDate mapDate(com.google.type.Date t) {
-		return LocalDate.of(t.getYear(), t.getMonth(), t.getDay());
+		return t != null
+				? LocalDate.of(t.getYear(), t.getMonth(), t.getDay())
+				: LocalDate.of(1970, 1, 1);
 	}
 
 	default com.google.type.TimeOfDay mapLocalTime(LocalTime t) {
-		return com.google.type.TimeOfDay.newBuilder().setHours(t.getHour()).setMinutes(t.getMinute()).setSeconds(t.getSecond()).setNanos(t.getNano()).build();
+		return t != null
+				? com.google.type.TimeOfDay.newBuilder().setHours(t.getHour()).setMinutes(t.getMinute()).setSeconds(t.getSecond()).setNanos(t.getNano()).build()
+				: com.google.type.TimeOfDay.getDefaultInstance();
 	}
 
 	default LocalTime mapTimeOfDay(com.google.type.TimeOfDay t) {
-		return LocalTime.of(t.getHours(), t.getMinutes(), t.getSeconds(), t.getNanos());
+		return t != null
+				? LocalTime.of(t.getHours(), t.getMinutes(), t.getSeconds(), t.getNanos())
+				: LocalTime.MIDNIGHT;
 	}
 
 	default Timestamp map(LocalDateTime i) {
 		if (i == null) {
-			return null;
+			return Timestamp.getDefaultInstance();
 		}
 
 		TimeZone systemDefault = TimeZone.getDefault();
@@ -99,7 +99,9 @@ public interface ProtobufStandardMappings {
 	}
 
 	default Timestamp map(OffsetDateTime in) {
-		return Timestamp.newBuilder().setSeconds(in.toEpochSecond()).setNanos(0).build();
+		return in != null
+				? Timestamp.newBuilder().setSeconds(in.toEpochSecond()).setNanos(0).build()
+				: Timestamp.getDefaultInstance();
 	}
 
 	default float map(FloatValue f) {

--- a/support-lite/pom.xml
+++ b/support-lite/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/) and/or 
-	other contributors as indicated by the @authors tag. See the copyright.txt 
-	file in the distribution for a full listing of all contributors. Licensed 
-	under the Apache License, Version 2.0 (the "License"); you may not use this 
-	file except in compliance with the License. You may obtain a copy of the 
-	License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by 
-	applicable law or agreed to in writing, software distributed under the License 
-	is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-	KIND, either express or implied. See the License for the specific language 
+<!-- Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/) and/or
+	other contributors as indicated by the @authors tag. See the copyright.txt
+	file in the distribution for a full listing of all contributors. Licensed
+	under the Apache License, Version 2.0 (the "License"); you may not use this
+	file except in compliance with the License. You may obtain a copy of the
+	License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+	applicable law or agreed to in writing, software distributed under the License
+	is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied. See the License for the specific language
 	governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -32,6 +32,12 @@
             <artifactId>proto-google-common-protos</artifactId>
             <version>2.7.4</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protobuf.java.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/support-lite/src/main/java/no/entur/abt/mapstruct/ProtobufStandardMappings.java
+++ b/support-lite/src/main/java/no/entur/abt/mapstruct/ProtobufStandardMappings.java
@@ -9,12 +9,12 @@ package no.entur.abt.mapstruct;
  * Licensed under the EUPL, Version 1.1 or – as soon they will be
  * approved by the European Commission - subsequent versions of the
  * EUPL (the "Licence");
- * 
+ *
  * You may not use this work except in compliance with the Licence.
  * You may obtain a copy of the Licence at:
- * 
+ *
  * http://ec.europa.eu/idabc/eupl5
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the Licence is distributed on an "AS IS" basis,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,37 +44,36 @@ public interface ProtobufStandardMappings extends no.entur.abt.mapstruct.common.
 	ProtobufStandardMappings INSTANCE = Mappers.getMapper(ProtobufStandardMappings.class);
 
 	default Instant mapToInstant(Timestamp t) {
-		if (t == null || (t.getSeconds() == 0 && t.getNanos() == 0)) {
-			return null;
-		}
-		return Instant.ofEpochSecond(t.getSeconds(), t.getNanos());
+		return t != null
+				? Instant.ofEpochSecond(t.getSeconds(), t.getNanos())
+				: Instant.EPOCH;
 	}
 
 	default Long toEpochMilliseconds(Timestamp instance) {
-		Instant instant = mapToInstant(instance);
-		return instant == null ? null : instant.toEpochMilli();
+		return mapToInstant(instance).toEpochMilli();
 	}
 
 	default Timestamp mapToTimestamp(Instant i) {
-		if (i == null || i.getEpochSecond() == 0) {
-			return null;
-		}
-		return Timestamp.newBuilder().setSeconds(i.getEpochSecond()).setNanos(i.getNano()).build();
+		return i != null
+				? Timestamp.newBuilder().setSeconds(i.getEpochSecond()).setNanos(i.getNano()).build()
+				: Timestamp.getDefaultInstance();
 	}
 
-	default Timestamp fromEpochMilliseconds(Long instance) {
-		if (instance == null) {
-			return null;
-		}
-		Instant instant = Instant.ofEpochMilli(instance);
-		return mapToTimestamp(instant);
+	default Timestamp fromEpochMilliseconds(Long millis) {
+		return mapToTimestamp(Instant.ofEpochMilli(millis != null ? millis : 0L));
 	}
 
 	default Duration mapDuration(com.google.protobuf.Duration t) {
-		return Duration.ofSeconds(t.getSeconds(), t.getNanos());
+		return t != null
+				? Duration.ofSeconds(t.getSeconds(), t.getNanos())
+				: Duration.ZERO;
 	}
 
 	default com.google.protobuf.Duration mapDuration(Duration t) {
+		if (t == null) {
+			return com.google.protobuf.Duration.getDefaultInstance();
+		}
+
 		long seconds = t.getSeconds();
 		int nanos = t.getNano();
 

--- a/support-lite/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
+++ b/support-lite/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
@@ -66,9 +66,16 @@ public class ProtobufStandardMappingsTest {
 		assertEquals(l, back);
 	}
 
+	// No longer true with the new implementation that ban null.
 	@Test
+	@org.junit.jupiter.api.Disabled
 	public void mapToInstant_whenSecondsAndNanosIs0_thenMapToNull() {
 		assertNull(MAPPER.mapToInstant(Timestamp.newBuilder().build()));
+	}
+
+	@Test
+	public void mapToInstant_whenSecondsAndNanosIs0_thenMapToEPOCH() {
+		assertEquals(MAPPER.mapToInstant(Timestamp.newBuilder().build()), Instant.EPOCH);
 	}
 
 	@Test

--- a/support-lite/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
+++ b/support-lite/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
@@ -9,12 +9,12 @@ package no.entur.abt.mapstruct;
  * Licensed under the EUPL, Version 1.1 or – as soon they will be
  * approved by the European Commission - subsequent versions of the
  * EUPL (the "Licence");
- * 
+ *
  * You may not use this work except in compliance with the Licence.
  * You may obtain a copy of the Licence at:
- * 
+ *
  * http://ec.europa.eu/idabc/eupl5
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the Licence is distributed on an "AS IS" basis,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 
 public class ProtobufStandardMappingsTest {
 
@@ -112,4 +113,16 @@ public class ProtobufStandardMappingsTest {
 		assertEquals(pbDuration, MAPPER.mapDuration(duration));
 	}
 
+	@Test
+	void timestamp_toEpochMilli_equals_Timestamps_toMillis() {
+		// GIVEN
+		Timestamp nowTimestamp = MAPPER.mapToTimestamp(Instant.now());
+
+		// WHEN
+		long millis1 = MAPPER.toEpochMilliseconds(nowTimestamp);
+		long millis2 = Timestamps.toMillis(nowTimestamp);
+
+		// THEN
+		assertEquals(millis1, millis2);
+	}
 }

--- a/support-standard/src/main/java/no/entur/abt/mapstruct/ProtobufStandardMappings.java
+++ b/support-standard/src/main/java/no/entur/abt/mapstruct/ProtobufStandardMappings.java
@@ -9,12 +9,12 @@ package no.entur.abt.mapstruct;
  * Licensed under the EUPL, Version 1.1 or – as soon they will be
  * approved by the European Commission - subsequent versions of the
  * EUPL (the "Licence");
- * 
+ *
  * You may not use this work except in compliance with the Licence.
  * You may obtain a copy of the Licence at:
- * 
+ *
  * http://ec.europa.eu/idabc/eupl5
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the Licence is distributed on an "AS IS" basis,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,6 @@ import org.mapstruct.factory.Mappers;
 
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
-import com.google.protobuf.util.Timestamps;
 
 /***
  *
@@ -45,47 +44,35 @@ public interface ProtobufStandardMappings extends no.entur.abt.mapstruct.common.
 	ProtobufStandardMappings INSTANCE = Mappers.getMapper(ProtobufStandardMappings.class);
 
 	default Instant mapToInstant(Timestamp t) {
-		if (Timestamps.isValid(t) && (t.getSeconds() > 0 || t.getNanos() > 0)) {
-			return Instant.ofEpochSecond(t.getSeconds(), t.getNanos());
-		} else {
-			return null;
-		}
+		return t != null
+				? Instant.ofEpochSecond(t.getSeconds(), t.getNanos())
+				: Instant.EPOCH;
 	}
 
 	default Long toEpochMilliseconds(Timestamp instance) {
-		if (instance != null) {
-			return Timestamps.toMillis(instance);
-		} else {
-			return null;
-		}
+		return mapToInstant(instance).toEpochMilli();
 	}
 
 	default Timestamp mapToTimestamp(Instant i) {
-		if (i == null || i.getEpochSecond() == 0) {
-			return null;
-		} else {
-			return Timestamp.newBuilder().setSeconds(i.getEpochSecond()).setNanos(i.getNano()).build();
-		}
+		return i != null
+				? Timestamp.newBuilder().setSeconds(i.getEpochSecond()).setNanos(i.getNano()).build()
+				: Timestamp.getDefaultInstance();
 	}
 
-	default Timestamp fromEpochMilliseconds(long millis) {
-		return Timestamps.fromMillis(millis);
+	default Timestamp fromEpochMilliseconds(Long millis) {
+		return mapToTimestamp(Instant.ofEpochMilli(millis != null ? millis : 0L));
 	}
 
 	default Duration mapDuration(com.google.protobuf.Duration t) {
-		if (t != null) {
-			return Duration.ofSeconds(t.getSeconds(), t.getNanos());
-		} else {
-			return null;
-		}
+		return t != null
+				? Duration.ofSeconds(t.getSeconds(), t.getNanos())
+				: Duration.ZERO;
 	}
 
 	default com.google.protobuf.Duration mapDuration(Duration t) {
-		if (t != null) {
-			return Durations.fromNanos(t.toNanos());
-		} else {
-			return null;
-		}
+		return t != null
+				? Durations.fromNanos(t.toNanos())
+				: com.google.protobuf.Duration.getDefaultInstance();
 	}
 
 }

--- a/support-standard/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
+++ b/support-standard/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
@@ -9,12 +9,12 @@ package no.entur.abt.mapstruct;
  * Licensed under the EUPL, Version 1.1 or – as soon they will be
  * approved by the European Commission - subsequent versions of the
  * EUPL (the "Licence");
- * 
+ *
  * You may not use this work except in compliance with the Licence.
  * You may obtain a copy of the Licence at:
- * 
+ *
  * http://ec.europa.eu/idabc/eupl5
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the Licence is distributed on an "AS IS" basis,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -66,9 +66,16 @@ public class ProtobufStandardMappingsTest {
 		assertEquals(l, back);
 	}
 
+	// No longer true with the new implementation that ban null.
 	@Test
+	@org.junit.jupiter.api.Disabled
 	public void mapToInstant_whenSecondsAndNanosIs0_thenMapToNull() {
 		assertNull(MAPPER.mapToInstant(Timestamp.newBuilder().build()));
+	}
+
+	@Test
+	public void mapToInstant_whenSecondsAndNanosIs0_thenMapToEPOCH() {
+		assertEquals(MAPPER.mapToInstant(Timestamp.newBuilder().build()), Instant.EPOCH);
 	}
 
 	@Test


### PR DESCRIPTION
Here's the code that implements the ban of null return values from mappers.

- null return values from domain->proto mapper will end up with a NPE thrown by Protobuff.
- null return values from proto->domain is less dangerous but it is best to let the application decide what to do in a post-mapper step.

The changes consist of systematically return a "default' value: empty string or arrays, EPOCH, zero, or protobuff's getDefaultInstance.

Close #176 