### PR TITLE
Differ explicit epoch from null in timestamp conversion.

### DIFF
--- a/support-core/src/main/java/no/entur/abt/mapstruct/common/ProtobufStandardMappings.java
+++ b/support-core/src/main/java/no/entur/abt/mapstruct/common/ProtobufStandardMappings.java
@@ -141,6 +141,10 @@ public interface ProtobufStandardMappings {
     }
 
     default Instant mapToInstant(Timestamp t) {
+        if (t == null) {
+            return null;
+        }
+
         Timestamp sanitized = Timestamps.sanitize(t);
 
         if (sanitized != null) {
@@ -151,11 +155,11 @@ public interface ProtobufStandardMappings {
     }
 
     default Timestamp mapToTimestamp(Instant i) {
-        if (i == null || i.getEpochSecond() == 0) {
+        if (i == null) {
             return null;
-        } else {
-            Timestamp t = Timestamp.newBuilder().setSeconds(i.getEpochSecond()).setNanos(i.getNano()).build();
-            return Timestamps.sanitize(t);
         }
+
+        Timestamp t = Timestamp.newBuilder().setSeconds(i.getEpochSecond()).setNanos(i.getNano()).build();
+        return Timestamps.sanitize(t);
     }
 }

--- a/support-core/src/main/java/no/entur/abt/mapstruct/common/Timestamps.java
+++ b/support-core/src/main/java/no/entur/abt/mapstruct/common/Timestamps.java
@@ -46,9 +46,6 @@ public class Timestamps {
      * Sanitize Timestamps outside legal range where possible.
      */
     public static Timestamp sanitize(Timestamp t) {
-        if (t.getSeconds() == 0 && t.getNanos() == 0) {
-            return null; // Assuming null for epoch, cannot differentiate
-        }
         if (t.getNanos() < 0 || t.getNanos() >= NANOS_PER_SECOND) {
             throw new IllegalArgumentException(String.format("Timestamp is not valid. See proto definition for valid values. Seconds (%s) must be in range [-62,135,596,800, +253,402,300,799]. Nanos (%s) must be in range [0, +999,999,999].", t.getSeconds(), t.getNanos()));
         }

--- a/support-lite/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
+++ b/support-lite/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
@@ -67,8 +67,19 @@ public class ProtobufStandardMappingsTest {
 	}
 
 	@Test
-	public void mapToInstant_whenSecondsAndNanosIs0_thenMapToNull() {
-		assertNull(MAPPER.mapToInstant(Timestamp.newBuilder().build()));
+	public void testMapInstantToTimestampEpoch() {
+		Instant epoch = Instant.EPOCH;
+
+		Timestamp timestamp = MAPPER.mapToTimestamp(epoch);
+
+		Instant back = MAPPER.mapToInstant(timestamp);
+
+		assertEquals(epoch, back);
+	}
+
+	@Test
+	public void mapToInstant_whenSecondsAndNanosIsNull_thenMapToNull() {
+		assertNull(MAPPER.mapToInstant(null));
 	}
 
 	@Test

--- a/support-standard/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
+++ b/support-standard/src/test/java/no/entur/abt/mapstruct/ProtobufStandardMappingsTest.java
@@ -66,10 +66,21 @@ public class ProtobufStandardMappingsTest {
         assertEquals(l, back);
     }
 
+    @Test
+    public void testMapInstantToTimestampEpoch() {
+        Instant epoch = Instant.EPOCH;
+
+        Timestamp timestamp = MAPPER.mapToTimestamp(epoch);
+
+        Instant back = MAPPER.mapToInstant(timestamp);
+
+        assertEquals(epoch, back);
+    }
+
 
     @Test
-    public void mapToInstant_whenSecondsAndNanosIs0_thenMapToNull() {
-        assertNull(MAPPER.mapToInstant(Timestamp.newBuilder().build()));
+    public void mapToInstant_whenSecondsAndNanosIsNull_thenMapToNull() {
+        assertNull(MAPPER.mapToInstant(null));
     }
 
     @Test


### PR DESCRIPTION
I got a null point exception when I was mapping a pojo with a field with an explicit Instant.EPOCH value to a protocol buffer where the field of same name was a Timestamp.

It seems that the decision of mapping epoch to null was deliberate, but it did not feel correct to me. See the added test cases, and let me know if you would prefer a different fix.